### PR TITLE
feat: cross-files copy-paste by localStorage

### DIFF
--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -840,7 +840,8 @@ export class FileTreeContribution
         }
       },
       isEnabled: () =>
-        this.fileTreeModelService.pasteStore && this.fileTreeModelService.pasteStore.type !== PasteTypes.NONE,
+        (this.fileTreeModelService.pasteStore && this.fileTreeModelService.pasteStore.type !== PasteTypes.NONE) ||
+        !!localStorage.getItem('paste-uri-list'),
     });
 
     if (this.appConfig.isElectronRenderer) {

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -50,7 +50,7 @@ import { IOpenDialogOptions, IWindowDialogService, ISaveDialogOptions } from '@o
 import { TERMINAL_COMMANDS } from '@opensumi/ide-terminal-next';
 import { DEFAULT_WORKSPACE_SUFFIX_NAME, IWorkspaceService, UNTITLED_WORKSPACE } from '@opensumi/ide-workspace';
 
-import { IFileTreeService, PasteTypes, RESOURCE_VIEW_ID } from '../common';
+import { IFileTreeService, PasteTypes, PASTE_FILE_LOCAL_TOKEN, RESOURCE_VIEW_ID } from '../common';
 import { Directory } from '../common/file-tree-node.define';
 
 import { FileTree } from './file-tree';
@@ -841,7 +841,7 @@ export class FileTreeContribution
       },
       isEnabled: () =>
         (this.fileTreeModelService.pasteStore && this.fileTreeModelService.pasteStore.type !== PasteTypes.NONE) ||
-        !!localStorage.getItem('paste-uri-list'),
+        !!localStorage.getItem(PASTE_FILE_LOCAL_TOKEN),
     });
 
     if (this.appConfig.isElectronRenderer) {

--- a/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-model.service.ts
@@ -41,7 +41,7 @@ import { WorkbenchEditorService } from '@opensumi/ide-editor';
 import { FileStat } from '@opensumi/ide-file-service';
 import { IDialogService, IMessageService } from '@opensumi/ide-overlay';
 
-import { IFileTreeAPI, IFileTreeService, PasteTypes } from '../../common';
+import { IFileTreeAPI, IFileTreeService, PasteTypes, PASTE_FILE_LOCAL_TOKEN } from '../../common';
 import { Directory, File } from '../../common/file-tree-node.define';
 import { FileTreeModel } from '../file-tree-model';
 import { FILE_TREE_NODE_HEIGHT } from '../file-tree-node';
@@ -1570,7 +1570,7 @@ export class FileTreeModelService {
 
     // Also update pasteStore in localStorage
     try {
-      localStorage.setItem('paste-uri-list', JSON.stringify(from.map((uri) => uri.toString())));
+      localStorage.setItem(PASTE_FILE_LOCAL_TOKEN, JSON.stringify(from.map((uri) => uri.toString())));
     } catch {}
   };
 
@@ -1582,7 +1582,7 @@ export class FileTreeModelService {
     let pasteStore = this.pasteStore;
     if (!pasteStore) {
       try {
-        const localStorgeUriList = JSON.parse(localStorage.getItem('paste-uri-list') ?? '');
+        const localStorgeUriList = JSON.parse(localStorage.getItem(PASTE_FILE_LOCAL_TOKEN) ?? '');
         if (
           !Array.isArray(localStorgeUriList) ||
           !localStorgeUriList.length ||

--- a/packages/file-tree-next/src/common/index.ts
+++ b/packages/file-tree-next/src/common/index.ts
@@ -5,6 +5,7 @@ import { FileStat } from '@opensumi/ide-file-service';
 import { Directory, File } from './file-tree-node.define';
 
 export const FILE_EXPLORER_WELCOME_ID = 'file-explorer';
+export const PASTE_FILE_LOCAL_TOKEN = 'paste-uri-list';
 
 export const IFileTreeAPI = Symbol('IFileTreeAPI');
 export const IFileTreeService = Symbol('IFileTreeService');


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

### Background or solution

todo:

- [ ] localStorage 设置为 disposable
- [ ] ClipboardService 改为 core-common 共享给 browser 和 electron
- [ ] localStorge 操作重构至 ClipboardService

### Changelog
- Support cross-windows copy & paste
