### PR TITLE
feat: support native copy

### DIFF
--- a/packages/addons/src/browser/file-drop.service.ts
+++ b/packages/addons/src/browser/file-drop.service.ts
@@ -121,7 +121,7 @@ export class FileDropService extends WithEventBus implements IFileDropFrontendSe
     await this.fs.createFile(Uri.file(filePath.toString()).toString());
     await this.dropService.$ensureFileExist(file.name, targetDir);
     const reader = file.stream().getReader();
-    let res: ReadableStreamDefaultReadResult<Uint8Array> = await reader.read();
+    let res: ReadableStreamReadResult<Uint8Array> = await reader.read();
     while (!res.done) {
       await this.dropService.$writeStream(this.toBinaryString(res.value), file.name, targetDir, res.done);
       reporter(res.value?.byteLength);

--- a/packages/core-browser/src/services/clipboard.service.ts
+++ b/packages/core-browser/src/services/clipboard.service.ts
@@ -78,4 +78,20 @@ export class BrowserClipboardService implements IClipboardService {
       return [];
     }
   }
+  async hasResources(field?: string | undefined): Promise<boolean> {
+    try {
+      const localStorgeUriList = JSON.parse(localStorage.getItem(field ?? CLIPBOARD_FILE_TOKEN) ?? '');
+      if (
+        !Array.isArray(localStorgeUriList) ||
+        !localStorgeUriList.length ||
+        !localStorgeUriList.every((str) => typeof str === 'string' && URI.isUriString(str))
+      ) {
+        return false;
+      }
+      return true;
+    } catch (e) {
+      this.logger.error(e);
+      return false;
+    }
+  }
 }

--- a/packages/core-browser/src/services/electron-clipboard.service.ts
+++ b/packages/core-browser/src/services/electron-clipboard.service.ts
@@ -43,4 +43,20 @@ export class ElectronClipboardService implements INativeClipboardService {
       return [];
     }
   }
+  async hasResources(field?: string | undefined): Promise<boolean> {
+    try {
+      const buffer = await this.electronMainUIService.readClipboardBuffer(field ?? CLIPBOARD_FILE_TOKEN);
+      const list = JSON.parse(Buffer.from(buffer).toString('utf8'));
+      if (
+        !Array.isArray(list) ||
+        !list.length ||
+        !list.every((str) => typeof str === 'string' && URI.isUriString(str))
+      ) {
+        return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
 }

--- a/packages/core-common/src/clipboard.ts
+++ b/packages/core-common/src/clipboard.ts
@@ -23,4 +23,9 @@ export interface IClipboardService {
    * 读取资源
    */
   readResources(field?: string): Promise<URI[]>;
+
+  /**
+   * 是否存在资源
+   */
+  hasResources(field?: string): Promise<boolean>;
 }

--- a/packages/file-tree-next/src/browser/file-tree-contribution.ts
+++ b/packages/file-tree-next/src/browser/file-tree-contribution.ts
@@ -29,7 +29,6 @@ import {
   match,
   Schemes,
   TERMINAL_COMMANDS,
-  CLIPBOARD_FILE_TOKEN,
 } from '@opensumi/ide-core-browser';
 import { FilesExplorerFilteredContext } from '@opensumi/ide-core-browser/lib/contextkey/explorer';
 import {
@@ -848,7 +847,7 @@ export class FileTreeContribution
       },
       isEnabled: () =>
         (this.fileTreeModelService.pasteStore && this.fileTreeModelService.pasteStore.type !== PasteTypes.NONE) ||
-        !!localStorage.getItem(CLIPBOARD_FILE_TOKEN),
+        !!this.clipboardService.hasResources(),
     });
 
     if (this.appConfig.isElectronRenderer) {

--- a/packages/file-tree-next/src/browser/services/file-tree-dnd.service.ts
+++ b/packages/file-tree-next/src/browser/services/file-tree-dnd.service.ts
@@ -8,6 +8,8 @@ import {
   URI,
   ThrottledDelayer,
   FileStat,
+  encodeBase64,
+  BinaryBuffer,
 } from '@opensumi/ide-core-browser';
 import { FileTreeDropEvent } from '@opensumi/ide-core-common/lib/types/dnd';
 import { IFileServiceClient } from '@opensumi/ide-file-service';
@@ -102,6 +104,21 @@ export class DragAndDropService extends WithEventBus {
       'beingDraggedNodes',
       JSON.stringify(this.beingDraggedNodes.map((node) => node.uri.toString())),
     );
+
+    // 拖拽文件到桌面
+    // 仅支持单个文件 Chrome/Edge
+    if (draggedFile) {
+      const file = draggedFile as File;
+
+      if (file.uri.scheme === 'file') {
+        ev.dataTransfer.setData(
+          'DownloadURL',
+          `application/octet-stream:${file.displayName}:data:application/octet-stream;base64,${encodeBase64(
+            BinaryBuffer.fromString(file.filestat.uri),
+          )}`,
+        );
+      }
+    }
 
     draggedNodes.forEach((node) => {
       // 添加拖拽样式


### PR DESCRIPTION
### Types

<!-- Please delete this line and the unselected items below to keep the PR description clean -->

- [x] 🎉 New Features

support native copy

### Background or solution


https://user-images.githubusercontent.com/47357585/189546728-73fd8c1d-c6eb-41cf-800a-0c0c8c77c3a4.mov

只支持单个文件的拖拽

出于考虑内容没有通过 file-service 读取，直接将 文件 uri 作为内容

看了下当前 node 没有提供 create url from file 的后端 api 服务，如果加上的话可以通过 url 进行下载完整内容

### Changelog
